### PR TITLE
Potential fix for code scanning alert no. 2: Duplicate 'if' branches

### DIFF
--- a/internal/http/handlers/handlers.go
+++ b/internal/http/handlers/handlers.go
@@ -294,11 +294,7 @@ func (h *Handlers) TestSource(c *gin.Context) {
 		return
 	}
 
-	if result.Status == "ok" {
-		c.JSON(http.StatusOK, result)
-	} else {
-		c.JSON(http.StatusOK, result)
-	}
+	c.JSON(http.StatusOK, result)
 }
 
 func (h *Handlers) EnableSource(c *gin.Context) {


### PR DESCRIPTION
Potential fix for [https://github.com/hidatara-ds/evolipia-radar/security/code-scanning/2](https://github.com/hidatara-ds/evolipia-radar/security/code-scanning/2)

In general, when an `if` statement has identical `then` and `else` branches, the condition is redundant. The correct fix is to remove the conditional and keep a single copy of the common code, preserving existing behavior while simplifying the function and resolving the static analysis warning.

Here, in `internal/http/handlers/handlers.go`, within `func (h *Handlers) TestSource`, lines 297–301 currently wrap `c.JSON(http.StatusOK, result)` in an `if result.Status == "ok" { ... } else { ... }`. Since both branches are identical, the best fix is to delete the `if` statement entirely and replace it with a single `c.JSON(http.StatusOK, result)` call. This does not change any runtime behavior: regardless of `result.Status`, the same JSON was already returned. No new imports, methods, or definitions are needed; we only simplify the existing block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
